### PR TITLE
Remove trailing comma in compile_commands.json

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -204,12 +204,16 @@ if __name__ == '__main__':
     bazel_workspace_dir = os.environ['BUILD_WORKSPACE_DIRECTORY'] # Set by `bazel run`. Can't call `bazel info workspace` because bazel is running us outside the workspace.
     # Bazel gotcha warning: If you were tempted to use `bazel info execution_root` as the build working directory for compile_commands...search ImplementationReadme.md to learn why that breaks.
 
-    # Dump em to stdout as compile_commands.json entries
+    # Dump em to stdout as compile_commands.json 
+    first = True
     for files, command in outputs:
         for file in files:
+            if not first:
+                sys.stdout.write(',')
+            else:
+                first = False
             sys.stdout.write(json.dumps({
                 'file': file,
                 'command': command,
                 'directory': bazel_workspace_dir
             }, indent=2, check_circular=False))
-            sys.stdout.write(',')

--- a/extract.py
+++ b/extract.py
@@ -204,16 +204,12 @@ if __name__ == '__main__':
     bazel_workspace_dir = os.environ['BUILD_WORKSPACE_DIRECTORY'] # Set by `bazel run`. Can't call `bazel info workspace` because bazel is running us outside the workspace.
     # Bazel gotcha warning: If you were tempted to use `bazel info execution_root` as the build working directory for compile_commands...search ImplementationReadme.md to learn why that breaks.
 
-    # Dump em to stdout as compile_commands.json 
-    first = True
+    # Dump em to stdout as compile_commands.json entries
     for files, command in outputs:
         for file in files:
-            if not first:
-                sys.stdout.write(',')
-            else:
-                first = False
             sys.stdout.write(json.dumps({
                 'file': file,
                 'command': command,
                 'directory': bazel_workspace_dir
             }, indent=2, check_circular=False))
+            sys.stdout.write(',')

--- a/refresh.sh.template
+++ b/refresh.sh.template
@@ -64,4 +64,5 @@ printf "[" > compile_commands.json # Add json list around. Commands add their ow
 {get_commands}
 # End: Command template filled by Bazel
 
+sed -i '' '$ s/,$//' compile_commands.json # Remove extra, trailing comma
 printf "]" >> compile_commands.json

--- a/refresh.sh.template
+++ b/refresh.sh.template
@@ -64,4 +64,4 @@ printf "[" > compile_commands.json # Add json list around. Commands add their ow
 {get_commands}
 # End: Command template filled by Bazel
 
-printf "]" >> compile_commands.json # Yes, there's an extra comma at the end of the list, but clangd parses fine.
+printf "]" >> compile_commands.json


### PR DESCRIPTION
This removes the trailing comma in the output, even though clangd doesn't care about the comma, the c/c++ extension for vscode does. I currently get better results from the default c/c++ extension than from clangd (probably because my actual build uses gcc).

I haven't don't a huge amount of testing, just checked that it works for my project, I'm just running `bazel run @hedron_compile_commands//:refresh_all`