### PR TITLE
fixup expected name of the local repository

### DIFF
--- a/ImplementationReadme.md
+++ b/ImplementationReadme.md
@@ -17,7 +17,7 @@ Then point your main repo (from which you're seeing issues) to use your local de
 ```
 local_repository(
     name = "hedron_compile_commands",
-    path = "../bazel-compile-commands", # Or wherever you put it.
+    path = "../bazel-compile-commands-extractor", # Or wherever you put it.
 )
 ```
 


### PR DESCRIPTION
As this lives in a git repository called `bazel-compile-commands-extractor`, I guess it
is save to assume, that the local checkout is named the same. So lets make the hint on
how to setup a local developent environment less confusing.