### PR TITLE
add support on Windows

### DIFF
--- a/refresh.bat.template
+++ b/refresh.bat.template
@@ -1,0 +1,56 @@
+@echo off
+
+@REM Declair a temp file on windows
+set TMPFILE=%TEMP%\temp-bazel-compile-commands-extract
+
+@REM As a template, this file helps implement the refresh_compile_commands rule and is not part of the user interface.
+@REM See ImplementationReadme.md for top-level context--or refresh_compile_commands.bzl for narrower context.
+
+
+@REM Interface (after Bazel's template expansion):
+@REM `bazel run` to make autocomplete (and any other clang tooling!) reflect the latest Bazel build files.
+    @REM No arguments are needed; they're baked into the template expansion.
+@REM Output: a compile_commands.json in the workspace root that clang tooling (or you!) can look at to figure out how files are being compiled by Bazel
+
+@REM Bazel Template Interface: Expand get_commands into, for example:
+    @REM get_commands //:target_1 --important_flag1 --important_flag2=true
+    @REM get_commands //:target_2
+@REM More generally, each line should be:
+    @REM get_commands <label> <optional: flags>
+
+
+@REM Implementation:
+@REM Change into workspace's root so compile_commands.json goes the right place -- and so we can invoke Bazel on the repo within this script.
+cd "%BUILD_WORKSPACE_DIRECTORY%"
+
+@REM Chain output into compile_commands.json
+@REM Add json list around. Commands add their own commas. Note overwrite of file. (& printf skipping trailing newline.)
+echo [ > compile_commands.json
+
+@REM Begin: Command template filled by Bazel
+{get_commands}
+@REM End: Command template filled by Bazel
+
+echo ] >> compile_commands.json
+goto :EOF
+
+@REM Call with the same flags as `bazel build`, one target per call, followed by flags
+@REM Appends the entries to compile_commands.json
+:GET_COMMANDS
+@REM Log clear completion messages
+echo ">>> Analyzing commands used in %1"
+
+@REM Queries Bazel's C-family compile actions, and runs them through our extract.py reformatter
+@REM Aquery docs if you need em: https://docs.bazel.build/versions/master/aquery.html
+    @REM One bummer, not described in the docs, is that aquery filters over *all* actions for a given target, rather than just those that would be run by a build to produce a given output. This mostly isn't a problem, but can sometimes surface extra, unnecessary, misconfigured actions. Chris has emailed the authors to discuss and filed an issue so anyone reading this could track it: https://github.com/bazelbuild/bazel/issues/14156.
+@REM We switched to jsonproto instead of proto because of https://github.com/bazelbuild/bazel/issues/13404. We could change back when fixed--reverting most of the commit that added this line and tweaking the build file to depend on the target in that issue. That said, it's kinda nice to be free of the dependency, unless (OPTIMNOTE) jsonproto becomes a performance bottleneck compated to binary protos.
+bazel aquery "mnemonic('(Objc|Cpp)Compile',deps(%1))" --ui_event_filters=-info --noshow_progress --output=jsonproto %2 > "%TMPFILE%"
+if not "%ERRORLEVEL%" == "0" (
+    exit /b 1
+)
+bazel run @hedron_compile_commands//:extract --ui_event_filters=-info --noshow_progress <"%TMPFILE%" >> compile_commands.json
+if not "%ERRORLEVEL%" == "0" (
+    exit /b 1
+)
+del %TMPFILE%
+echo ">>> Finished extracting commands for %1"


### PR DESCRIPTION
> Issue related: #8 
To make things happen on Windows, we need a batch template which do simillar stuffs as the shell template.
And I try to escape from generating headers from CL which seems not quite feasible. But **clangd** managed to work without the header files as long as the `/I` is correct for searching headers.