### PR TITLE
Parse inputs from ActionGraphContainer instead of arguments

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -28,7 +28,6 @@ import shlex
 import subprocess
 import types
 import typing # MIN_PY=3.9: Switch e.g. typing.List[str] -> list[str]
-import itertools
 
 def pairwise(iterable):
     a, b = itertools.tee(iterable)
@@ -112,7 +111,7 @@ def _get_files(compile_args: typing.List[str]):
     source_files = [
         arg
         for previous, arg in pairwise(compile_args)
-        if arg.endswith(_get_files.source_extensions) and not previous == "-isystem"
+        if arg.endswith(_get_files.source_extensions) and previous == "-c"
     ]
 
     assert len(source_files) > 0, f"No sources detected in {compile_args}"


### PR DESCRIPTION
For some targets the assert for multiple source files in `_get_files` stops the compile commands extraction.
This is due to some generated directories ending with source file extensions.

example:
```
'-isystem', 'bazel-out/k8-opt/bin/someip-posix.cc'
```

This change does not interpret arguments as source files if the previous argument is `-isystem`.