### PR TITLE
Tweak suggested --query-driver flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Add the following three separate entries to `"clangd.arguments"`:
 ```Shell
 --header-insertion=never
 --compile-commands-dir=${workspaceFolder}/
---query-driver=/**/*
+--query-driver=**
 ```
 (Just copy each as written; VSCode will correctly expand ${workspaceFolder} for each workspace.)
   -  They get rid of (overzealous) header insertion; locate the compile commands correctly, even when browsing system headers outside the source tree; and cause clangd to interrogate Bazel's compiler wrappers to figure out which system headers are included by default.


### PR DESCRIPTION
On Windows, a leading slash would cause the glob to not match anything.

I ran into this while building with arm-none-eabi-gcc. Clangd couldn't find any of the system headers and I spent a while scratching my head about it. Unexpectedly(?), clangd matches the query-driver glob [textually and not as a logical path](https://github.com/llvm/llvm-project/blob/fd4afa7a29061e51e8b18e83afa5c5172ee76aa0/clang-tools-extra/clangd/QueryDriverDatabase.cpp#L273), so "C:/tools/foo/bar" will not match "/**/*".