### PR TITLE
Support select() in refresh_compile_commands macro

### DIFF
--- a/refresh_compile_commands.bzl
+++ b/refresh_compile_commands.bzl
@@ -68,6 +68,10 @@ def refresh_compile_commands(
     # In Python, `type(x) == y` is an antipattern, but [Starlark doesn't support inheritance](https://bazel.build/rules/language), so `isinstance` doesn't exist, and this is the correct way to switch on type.
     if not targets:  # Default to all targets in main workspace
         targets = {"@//...": ""}
+    elif type(targets) == "select": # Allow select: https://bazel.build/reference/be/functions#select
+        # Pass select() to _expand_template to make it work
+        # see https://bazel.build/docs/configurable-attributes#faq-select-macro
+        pass
     elif type(targets) == "list":  # Allow specifying a list of targets w/o arguments
         targets = {target: "" for target in targets}
     elif type(targets) != "dict":  # Assume they've supplied a single string/label and wrap it


### PR DESCRIPTION
e.g., from https://bazel.build/docs/configurable-attributes#configurable-build-example: 

```Starlark
# BUILD 

cc_binary(
    name = "mybinary",
    srcs = ["main.cc"],
    deps = select({
        ":arm_build": [":arm_lib"],
        ":x86_debug_build": [":x86_dev_lib"],
        "//conditions:default": [":generic_lib"],
    }),
)

config_setting(
    name = "arm_build",
    values = {"cpu": "arm"},
)

config_setting(
    name = "x86_debug_build",
    values = {
        "cpu": "x86",
        "compilation_mode": "dbg",
    },
)

refresh_compile_commands(
    name = "refresh_mybinary_commands",

    targets = select({
      ":arm_build":{ "//:mybinary": "--cpu=arm"},
      ":x86_debug_build":{ "//:mybinary": "-c dbg --cpu=x86"},
      "//conditions:default": { "//:mybinary": ""},
    }),
)
```

Run `bazel //:refresh_mybinary_commands --cpu=arm` will `select` the ":arm_build" config.

See more details: https://bazel.build/docs/configurable-attributes#faq-select-macro