### PR TITLE
Add support for swift

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -917,11 +917,6 @@ def _get_commands(target: str, flags: str):
     Try adding them as flags in your refresh_compile_commands rather than targets.
     In a moment, Bazel will likely fail to parse.""")
 
-    support_mnemonics = ["Objc", "Cpp"]
-    if {enable_swift}:
-        support_mnemonics += ["Swift"]
-    mnemonics_string = '|'.join(support_mnemonics)
-
     # First, query Bazel's C-family compile actions for that configured target
     aquery_args = [
         'bazel',
@@ -929,7 +924,7 @@ def _get_commands(target: str, flags: str):
         # Aquery docs if you need em: https://docs.bazel.build/versions/master/aquery.html
         # Aquery output proto reference: https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/analysis_v2.proto
         # One bummer, not described in the docs, is that aquery filters over *all* actions for a given target, rather than just those that would be run by a build to produce a given output. This mostly isn't a problem, but can sometimes surface extra, unnecessary, misconfigured actions. Chris has emailed the authors to discuss and filed an issue so anyone reading this could track it: https://github.com/bazelbuild/bazel/issues/14156.
-        f"mnemonic('({mnemonics_string})Compile',deps({target}))",
+        f"mnemonic('(Objc|Cpp{swift_mnemonic_string})Compile',deps({target}))",
         # We switched to jsonproto instead of proto because of https://github.com/bazelbuild/bazel/issues/13404. We could change back when fixed--reverting most of the commit that added this line and tweaking the build file to depend on the target in that issue. That said, it's kinda nice to be free of the dependency, unless (OPTIMNOTE) jsonproto becomes a performance bottleneck compated to binary protos.
         '--output=jsonproto',
         # We'll disable artifact output for efficiency, since it's large and we don't use them. Small win timewise, but dramatically less json output from aquery.

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -723,7 +723,7 @@ def _apple_platform_patch(compile_args: typing.List[str], environmentVariables =
         # Bazel wraps the compiler as `external/local_config_cc/wrapped_clang` and exports that wrapped compiler in the proto. However, we need a clang call that clangd can introspect. (See notes in "how clangd uses compile_commands.json" in ImplementationReadme.md for more.)
         # Bazel wrapps the swiftc as `external/build_bazel_rules_swift/tools/worker/worker swiftc ` and worker has been removed in apple_swift_patch
         # Removing the wrapper is also important because Bazel's Xcode (but not CommandLineTools) wrapper crashes if you don't specify particular environment variables (replaced below). We'd need the wrapper to be invokable by clangd's --query-driver if we didn't remove the wrapper.
-        
+
         if compile_args[0].endswith('swiftc'):
             compile_args[0] = 'swiftc'
         else:

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -107,8 +107,8 @@ def _warn_if_file_doesnt_exist(source_file):
         You can either use a refresh_compile_commands rule or the special -- syntax. Please see the README.
         [Supplying flags normally won't work. That just causes this tool to be built with those flags.]
     Continuing gracefully...""")
-        return False
-    return True
+        return True
+    return False
 _warn_if_file_doesnt_exist.has_logged_missing_file_error = False
 
 @functools.lru_cache(maxsize=None)
@@ -594,7 +594,7 @@ def _get_files(compile_action):
     assert source_file.endswith(_get_files.source_extensions), f"Source file candidate, {source_file}, seems to be wrong.\nSelected from {compile_action.arguments}.\nPlease file an issue with this information!"
 
     # Warn gently about missing files
-    if not _warn_if_file_doesnt_exist(source_file):
+    if _warn_if_file_doesnt_exist(source_file):
         return {source_file}, set()
 
     # Note: We need to apply commands to headers and sources.

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -704,14 +704,7 @@ def _apple_swift_patch(compile_args: typing.List[str]):
     # We need to remove it (build_bazel_rules_swift/tools/worker/worker)
     compile_args.pop(0)
 
-    # The worker also expand the arguments defined in swift_rule which was start with -Xwrapped-swift
-    # Expand -debug-prefix-pwd-is-dot
-    match = next((i for i,v in enumerate(compile_args) if v == "-Xwrapped-swift=-debug-prefix-pwd-is-dot"), None)
-    if match:
-        compile_args[match] = "-debug-prefix-map"
-        compile_args.insert(match + 1, os.environ["BUILD_WORKSPACE_DIRECTORY"] + "=.")
-
-    # Remove other -Xwrapped-swift arguments like `-ephemeral-module-cache` `-global-index-store-import-path`
+    # Remove other -Xwrapped-swift arguments like `-debug-prefix-pwd-is-dot` `-ephemeral-module-cache` `-global-index-store-import-path`
     # We could override index-store by config sourcekit-lsp
     compile_args = [arg for arg in compile_args if not arg.startswith('-Xwrapped-swift')]
 

--- a/refresh_compile_commands.bzl
+++ b/refresh_compile_commands.bzl
@@ -63,6 +63,7 @@ def refresh_compile_commands(
         targets = None,
         exclude_headers = None,
         exclude_external_sources = False,
+        enable_swift = False,
         **kwargs):  # For the other common attributes. Tags, compatible_with, etc. https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes.
     # Convert the various, acceptable target shorthands into the dictionary format
     # In Python, `type(x) == y` is an antipattern, but [Starlark doesn't support inheritance](https://bazel.build/rules/language), so `isinstance` doesn't exist, and this is the correct way to switch on type.
@@ -79,7 +80,7 @@ def refresh_compile_commands(
 
     # Generate runnable python script from template
     script_name = name + ".py"
-    _expand_template(name = script_name, labels_to_flags = targets, exclude_headers = exclude_headers, exclude_external_sources = exclude_external_sources, **kwargs)
+    _expand_template(name = script_name, labels_to_flags = targets, exclude_headers = exclude_headers, exclude_external_sources = exclude_external_sources, enable_swift = enable_swift, **kwargs)
     native.py_binary(name = name, srcs = [script_name], **kwargs)
 
 def _expand_template_impl(ctx):
@@ -95,6 +96,7 @@ def _expand_template_impl(ctx):
             "        {windows_default_include_paths}": "\n".join(["        %r," % path for path in find_cpp_toolchain(ctx).built_in_include_directories]),  # find_cpp_toolchain is from https://docs.bazel.build/versions/main/integrating-with-rules-cc.html
             "{exclude_headers}": '"' + str(ctx.attr.exclude_headers) + '"',
             "{exclude_external_sources}": str(ctx.attr.exclude_external_sources),
+            "{enable_swift}": str(ctx.attr.enable_swift),
         },
     )
     return DefaultInfo(files = depset([script]))
@@ -104,6 +106,7 @@ _expand_template = rule(
         "labels_to_flags": attr.string_dict(mandatory = True),  # string keys instead of label_keyed because Bazel doesn't support parsing wildcard target patterns (..., *, :all) in BUILD attributes.
         "exclude_external_sources": attr.bool(default = False),
         "exclude_headers": attr.string(values = ["all", "external", ""]), # "" needed only for compatibility with Bazel < 3.6.0
+        "enable_swift": attr.bool(default = False),
         "_script_template": attr.label(allow_single_file = True, default = "refresh.template.py"),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),  # For Windows INCLUDE. If this were eliminated, for example by the resolution of https://github.com/clangd/clangd/issues/123, we'd be able to just use a macro and skylib's expand_template rule: https://github.com/bazelbuild/bazel-skylib/pull/330
     },


### PR DESCRIPTION
Add support for `SwiftCompile` in [rule_swift](https://github.com/bazelbuild/rules_swift)

It extracts swift compile commands into `compile_commands.json` providing to [sourcekit-lsp](http://github.com/apple/sourcekit-lsp)

---

VSCode setup
```
code --install-extension sswg.swift-lang
```

Examples:
```BUILD
load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")

swift_library(
    name = "Sources",
    srcs = [
        "ViewController.swift",
    ],
    deps = [
         #objc_library
        "//lib:hello",
    ]
)

refresh_compile_commands(
    name = "refresh",
    enable_swift = True,
    targets = {
      "//:Sources": "--apple_platform_type=ios --cpu=ios_arm64",
    }
)
```

```Shell
# Create compile_commands.json
bazel run //:refresh
# Build .swiftmodule
bazel build //:Sources --apple_platform_type=ios --cpu=ios_arm64
# Open is vscode
code .
```
