### PR TITLE
Support source_filter_packages

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -861,7 +861,7 @@ def _get_commands(target: str, flags: str):
         # Aquery docs if you need em: https://docs.bazel.build/versions/master/aquery.html
         # Aquery output proto reference: https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/analysis_v2.proto
         # One bummer, not described in the docs, is that aquery filters over *all* actions for a given target, rather than just those that would be run by a build to produce a given output. This mostly isn't a problem, but can sometimes surface extra, unnecessary, misconfigured actions. Chris has emailed the authors to discuss and filed an issue so anyone reading this could track it: https://github.com/bazelbuild/bazel/issues/14156.
-        f"mnemonic('(Objc|Cpp)Compile',deps({target}))",
+        f"mnemonic('(Objc|Cpp)Compile', filter('({source_filter_packages})', deps({target})))",
         # We switched to jsonproto instead of proto because of https://github.com/bazelbuild/bazel/issues/13404. We could change back when fixed--reverting most of the commit that added this line and tweaking the build file to depend on the target in that issue. That said, it's kinda nice to be free of the dependency, unless (OPTIMNOTE) jsonproto becomes a performance bottleneck compated to binary protos.
         '--output=jsonproto',
         # We'll disable artifact output for efficiency, since it's large and we don't use them. Small win timewise, but dramatically less json output from aquery.


### PR DESCRIPTION
Close #93 

Add support for filter source packages
The following name are supported

```
['@third//', '@third', '@third//foo', '@third//foo:bar', '@third//...']
['//...', '//foo', 'foo', '//foo:bar', '//foo:...']
```