### PR TITLE
Add customization for git ignore file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -8,9 +8,8 @@ refresh_compile_commands(
     name = "refresh_all",
 )
 
-
 ########################################
 # Implementation:
 # If you are looking into the implementation, start with the overview in ImplementationReadme.md.
 
-exports_files(["refresh.template.py"]) # For implicit use by refresh_compile_commands.
+exports_files(["refresh.template.py"])  # For implicit use by refresh_compile_commands.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,8 +1,9 @@
 # This file existed originally to enable quick local development via local_repository.
-    # See ./ImplementationReadme.md for details on local development.
-    # Why? local_repository didn't work without a WORKSPACE, and new_local_repository required overwriting the BUILD file (as of Bazel 5.0).
+# See ./ImplementationReadme.md for details on local development.
+# Why? local_repository didn't work without a WORKSPACE, and new_local_repository required overwriting the BUILD file (as of Bazel 5.0).
 
 workspace(name = "hedron_compile_commands")
 
 load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
 hedron_compile_commands_setup()

--- a/private/util.bzl
+++ b/private/util.bzl
@@ -1,0 +1,39 @@
+"""
+Utility functions for reading/writing workspace setup information.
+"""
+
+def write_dict_entries(d, indent_level = 1):
+    """Write the entries of dictionary to a string."""
+    return "\n".join([
+        "{indent}\"{key}\": \"{value}\",".format(
+            indent = indent_level * 4 * " ",
+            key = key,
+            value = value,
+        )
+        for key, value in d.items()
+    ])
+
+def _write_install_config_impl(rctx):
+    rctx.file("WORKSPACE.bazel", executable = False)
+    rctx.file("BUILD.bazel", executable = False)
+
+    entries = write_dict_entries(rctx.attr.install_config)
+
+    rctx.file(
+        "config.bzl",
+        content = """
+INSTALL_CONFIG = {{
+{entries}
+}}
+""".format(entries = entries),
+        executable = False,
+    )
+
+write_install_config = repository_rule(
+    implementation = _write_install_config_impl,
+    attrs = {
+        "install_config": attr.string_dict(
+            doc = "Installation configuration parameters (e.g. gitignore file).",
+        ),
+    },
+)

--- a/workspace_setup.bzl
+++ b/workspace_setup.bzl
@@ -1,6 +1,7 @@
 # Do not change the filename; it is part of the user interface.
+load("//:private/util.bzl", _write_install_config = "write_install_config")
 
-def hedron_compile_commands_setup():
+def hedron_compile_commands_setup(install_config = {}):
     """Set up a WORKSPACE to have hedron_compile_commands used within it."""
 
     # Unified setup for users' WORKSPACES and this workspace when used standalone.
@@ -8,6 +9,7 @@ def hedron_compile_commands_setup():
     #     README.md (for users)
     #     WORKSPACE (for working on this repo standalone)
 
-    # Currently nothing to do -> no-op.
-    # So why is this even here? Enables future expansion (e.g to add transitive dependencies) without changing the user interface.
-    pass
+    _write_install_config(
+        name = "hedron_compile_commands_install_config",
+        install_config = install_config,
+    )


### PR DESCRIPTION
Define `hedron_compile_commands_setup` to perform installation configuration. Values set during this step remain constant across invocations of `refresh_compile_commands`.

This commit introduces a single install config parameter `ignore_file`. If not set, `.gitignore` is used. This can be replaced with the local, unversioned ignore file `.git/info/exclude`.