### PR TITLE
Use shell to resolve `bazel`

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -884,6 +884,7 @@ def _get_commands(target: str, flags: str):
         capture_output=True,
         encoding=locale.getpreferredencoding(),
         check=False, # We explicitly ignore errors from `bazel aquery` and carry on.
+        shell=True, # Resolve `bazel` using the shell. Otherwise user aliases are not visible in subprocess.
     )
 
 

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -102,6 +102,7 @@ def _get_bazel_cached_action_keys():
         capture_output=True,
         encoding=locale.getpreferredencoding(),
         check=True, # Should always succeed.
+        shell=True, # Resolve `bazel` using the shell. Otherwise user aliases are not visible in subprocess.
     )
 
     action_keys = set()


### PR DESCRIPTION
Otherwise user shell aliases are not visible in `subprocess`. This helps in systems where `bazel` might not be directly in the PATH, but rather aliased to a specific location.