### PR TITLE
Custom-control-args

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ Please upgrade or add `# gazelle:exclude external` to the BUILD file in your wor
 The tool has a few parameters that control output generation:
 
 * `--bcce-color[=`_no_`]`           A boolean flag that enables or disables colored output. This is useful for environments where the color codes are not handled (e.g. VSCode output window).
-* `--bcce-compiler=[`_compiler_`]`  Allows to override the detected compiler. This is helpful if the compiler found in the editor environment is different from the compiler that should be used for `compile_commands.json`.
-* `--bcce-copt=[`_option_`]`        Enables passing additional `option`s to arg lists in  `compile_commands.json` (can be repeated).
+* `--bcce-compiler[=`_compiler_`]`  Allows to override the detected compiler. This is helpful if the compiler found in the editor environment is different from the compiler that should be used for `compile_commands.json`.
+* `--bcce-copt[=`_option_`]`        Enables passing additional `option`s to arg lists in  `compile_commands.json` (can be repeated).
 
 Similar to optons passed down to the bazel aquery, these options must be separated by `--`. For instance in order to suppress colored output use:
 

--- a/README.md
+++ b/README.md
@@ -147,11 +147,12 @@ Please upgrade or add `# gazelle:exclude external` to the BUILD file in your wor
 
 The tool has a few parameters that control output generation:
 
-* `--bcce-color[=`_no_`]`           A boolean flag that enables or disables colored output. This is useful for environments where the color codes are not handled (e.g. VSCode output window). The flag also suppots the `--nobcce-color` notation.
-* `--bcce-compiler[=`_compiler_`]`  Allows to override the detected compiler. This is helpful if the compiler found in the editor environment is different from the compiler that should be used for `compile_commands.json`.
-* `--bcce-copt[=`_option_`]`        Enables passing additional `option`s to arg lists in  `compile_commands.json` (can be repeated).
+* `--bcce-color[=`_auto_`]`           A flag that enables or disables colored output. This is useful for environments where the color codes are not handled (e.g. VSCode OUTPUT window). If the value is `auto` (default), then the environment is checked to determne whetehr colors can be used (both [`NO_COLOR`](https://no-color.org) and `TERM` are checked). To disabe colors the value needs to be `0` or `no`, or the flag specified as `--nobcce-color`. To enable colors the value needs to be `1` or `yes`.
+* `--bcce-compiler[=`_compiler_`]`  Allows to override the detected compiler. This is helpful if the compiler found in the editor environment is different from the compiler that should be used for `compile_commands.json`. Note that this
+may interfere with cross-compilation. If the issue is with `clangd`, then the [clangd compileflags](https://clangd.llvm.org/config#compileflags) can be used so clangd will perform the override for its own use.
+* `--bcce-copt[=`_option_`]`        Enables passing additional `option`s to arg lists in `compile_commands.json` (can be repeated). Similar to the above, compiler options can be added and removed using clangd's compileflags.
 
-Similar to optons passed down to the bazel aquery, these options must be separated by `--`. For instance in order to suppress colored output use:
+Similar to options passed down to `bazel aquery`, these options must be separated by `--`. For instance in order to suppress colored output use:
 
 `bazel run @hedron_compile_commands//:refresh_all -- --bcce-color=no`.
 
@@ -206,9 +207,9 @@ After installing the plugin add the following to your user `settings.json` file:
     "emeraldwalk.runonsave": {
         "commands": [
             {
-                "match": "WORKSPACE|BUILD|.*[.]bzl|.*[.]bazel",
+                "match": "(WORKSPACE|BUILD|.*[.]bzl|.*[.]bazel)$",
                 "isAsync": true,
-                "cmd": "bazel run @hedron_compile_commands//:refresh_all -- --bcce-color=0 --bcce-compiler=$(which clang))"
+                "cmd": "bazel run @hedron_compile_commands//:refresh_all"
             }
         ]
     }

--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ For now, we'd suggest continuing on to set up `clangd` (below). Thereafter, if y
 
 Please upgrade or add `# gazelle:exclude external` to the BUILD file in your workspace root. Gazelle had some problematic symlink handling in those versions that we fixed for them with a PR. (Conversely, if, at the time you're reading this, Gazelle v0.29 (January 2023) is so old that few would be using it, please file a quick PR to remove this section.)
 
+### Customizing the `compile_commands.json` generation
+
+The tool has a few parameters that control output generation:
+
+* `--bcce-color[=`_no_`]`           A boolean flag that enables or disables colored output. This is useful for environments where the color codes are not handled (e.g. VSCode output window).
+* `--bcce-compiler=[`_compiler_`]`  Allows to override the detected compiler. This is helpful if the compiler found in the editor environment is different from the compiler that should be used for `compile_commands.json`.
+* `--bcce-copt=[`_option_`]`        Enables passing additional `option`s to arg lists in  `compile_commands.json` (can be repeated).
+
+Similar to optons passed down to the bazel aquery, these options must be separated by `--`. For instance in order to suppress colored output use:
+
+`bazel run @hedron_compile_commands//:refresh_all -- --bcce-color=no`.
+
 ## Editor Setup — for autocomplete based on `compile_commands.json`
 
 
@@ -182,6 +194,28 @@ You may need to subsequently reload VSCode [(CMD/CTRL+SHIFT+P)->reload] for the 
 #### If you work on your repository with others...
 
 ... and would like these settings to be automatically applied for your teammates, also add the settings to the VSCode *workspace* settings and then check `.vscode/settings.json` into source control.
+
+#### Automating the regeneration of `compile_commands.json`
+
+There are VSCode plugins that allow to run commands whenever a file is being saved. One such extension is [Run on Save from emeraldwalk](https://github.com/emeraldwalk/vscode-runonsave).
+
+After installing the plugin add the following to your user `settings.json` file:
+
+```json
+{
+    "emeraldwalk.runonsave": {
+        "commands": [
+            {
+                "match": "WORKSPACE|BUILD|.*[.]bzl|.*[.]bazel",
+                "isAsync": true,
+                "cmd": "bazel run @hedron_compile_commands//:refresh_all -- --bcce-color=0 --bcce-compiler=$(which clang))"
+            }
+        ]
+    }
+}
+```
+
+The above only triggers on Bazel's `WORKSPACE`, `BUILD` and other bazel files, as changes to the header files or dependencies require a change in those files.
 
 ### Other Editors
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Please upgrade or add `# gazelle:exclude external` to the BUILD file in your wor
 
 The tool has a few parameters that control output generation:
 
-* `--bcce-color[=`_no_`]`           A boolean flag that enables or disables colored output. This is useful for environments where the color codes are not handled (e.g. VSCode output window).
+* `--bcce-color[=`_no_`]`           A boolean flag that enables or disables colored output. This is useful for environments where the color codes are not handled (e.g. VSCode output window). The flag also suppots the `--nobcce-color` notation.
 * `--bcce-compiler[=`_compiler_`]`  Allows to override the detected compiler. This is helpful if the compiler found in the editor environment is different from the compiler that should be used for `compile_commands.json`.
 * `--bcce-copt[=`_option_`]`        Enables passing additional `option`s to arg lists in  `compile_commands.json` (can be repeated).
 

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -743,7 +743,7 @@ def _manual_platform_patch(compile_args: typing.List[str]):
     compile_args[0] = _get_last_arg('bcce-compiler', compile_args[0])
     compile_args += _get_args('bcce-copt')
     return compile_args
-    
+
 
 def _apple_platform_patch(compile_args: typing.List[str]):
     """De-Bazel the command into something clangd can parse.

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -103,7 +103,7 @@ def _can_do_color() -> bool:
         return False
     if USE_COLOR == COLOR_MODE.COLOR_YES:
         return True
-    
+
     if _get_last_arg('bcce-color', default='auto', is_bool=True) != 'auto':
         if _get_bool_arg('bcce-color', True):
             USE_COLOR=COLOR_MODE.COLOR_YES

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -49,9 +49,45 @@ class SGR(enum.Enum):
     FG_BLUE = '\033[0;34m'
 
 
+@functools.lru_cache(maxsize=None)
+def _non_bcce_args():
+    """Returns `sys.argv[1:]` with all bcce args removed."""
+    return [arg for arg in sys.argv[1:] if not arg.startswith('--bcce-')]
+
+
+@functools.lru_cache(maxsize=None)
+def _get_args(arg_name):
+    """Return all values for `arg_name` in `sys.argv[1:]`."""
+    return [arg.lstrip('--' + arg_name).lstrip('=') for arg in sys.argv[1:] if arg.startswith('--' + arg_name)]
+
+
+@functools.lru_cache(maxsize=None)
+def _get_last_arg(arg_name, default = None):
+    """Get last value for `arg_name` in `sys.argv[1:]`."""
+    args = _get_args(arg_name)
+    return args[-1] if args else default
+
+
+@functools.lru_cache(maxsize=None)
+def _get_bool_arg(arg_name, default):
+    """Get the last value for `arg_name` in `sys.argv[1:]` as boolean or `default` value."""
+    value = _get_last_arg(arg_name)
+    if value in ['', '1', 'yes']:
+        return True
+    if value in ['0', 'no']:
+        return False
+    return default
+
+
 def _log_with_sgr(sgr, colored_message, uncolored_message=''):
     """Log a message to stderr wrapped in an SGR context."""
-    print(sgr.value, colored_message, SGR.RESET.value, uncolored_message, sep='', file=sys.stderr, flush=True)
+    if _get_bool_arg('bcce-color', True):
+        sgr_start = sgr.value
+        sgr_reset = SGR.RESET.value
+    else:
+        sgr_start = ''
+        sgr_reset = ''
+    print(sgr_start, colored_message, sgr_reset, uncolored_message, sep='', file=sys.stderr, flush=True)
 
 
 def log_error(colored_message, uncolored_message=''):
@@ -702,6 +738,13 @@ def _get_apple_DEVELOPER_DIR():
     # Traditionally stored in DEVELOPER_DIR environment variable, but not provided by Bazel. See https://github.com/bazelbuild/bazel/issues/12852
 
 
+def _manual_platform_patch(compile_args: typing.List[str]):
+    """Apply manual fixes to the compile args."""
+    compile_args[0] = _get_last_arg('bcce-compiler', compile_args[0])
+    compile_args += _get_args('bcce-copt')
+    return compile_args
+    
+
 def _apple_platform_patch(compile_args: typing.List[str]):
     """De-Bazel the command into something clangd can parse.
 
@@ -773,6 +816,7 @@ def _get_cpp_command_for_files(compile_action):
     # Patch command by platform
     compile_action.arguments = _all_platform_patch(compile_action.arguments)
     compile_action.arguments = _apple_platform_patch(compile_action.arguments)
+    compile_action.arguments = _manual_platform_patch(compile_action.arguments)
     # Android and Linux and grailbio LLVM toolchains: Fine as is; no special patching needed.
 
     source_files, header_files = _get_files(compile_action)
@@ -835,7 +879,7 @@ def _get_commands(target: str, flags: str):
     # Log clear completion messages
     log_info(f">>> Analyzing commands used in {target}")
 
-    additional_flags = shlex.split(flags) + sys.argv[1:]
+    additional_flags = shlex.split(flags) + _non_bcce_args()
 
     # Detect anything that looks like a build target in the flags, and issue a warning.
     # Note that positional arguments after -- are all interpreted as target patterns. (If it's at the end, then no worries.)

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -52,26 +52,32 @@ class SGR(enum.Enum):
 @functools.lru_cache(maxsize=None)
 def _non_bcce_args():
     """Returns `sys.argv[1:]` with all bcce args removed."""
-    return [arg for arg in sys.argv[1:] if not arg.startswith('--bcce-')]
+    return [arg for arg in sys.argv[1:] if not arg.startswith('--bcce-') and not arg.startswith('--nobcce')]
 
 
 @functools.lru_cache(maxsize=None)
-def _get_args(arg_name):
+def _get_args(arg_name, is_bool=False):
     """Return all values for `arg_name` in `sys.argv[1:]`."""
-    return [arg.lstrip('--' + arg_name).lstrip('=') for arg in sys.argv[1:] if arg.startswith('--' + arg_name)]
+    args = []
+    for arg in sys.argv[1:]:
+        if arg.startswith('--'+arg_name):
+            args.append(arg.lstrip('--' + arg_name).lstrip('='))
+        if is_bool and arg.startswith('--no' + arg_name):
+            args.append('no' + arg.lstrip('--no' + arg_name).lstrip('='))
+    return args
 
 
 @functools.lru_cache(maxsize=None)
-def _get_last_arg(arg_name, default = None):
+def _get_last_arg(arg_name, default = None, is_bool=False):
     """Get last value for `arg_name` in `sys.argv[1:]`."""
-    args = _get_args(arg_name)
+    args = _get_args(arg_name, is_bool)
     return args[-1] if args else default
 
 
 @functools.lru_cache(maxsize=None)
 def _get_bool_arg(arg_name, default):
     """Get the last value for `arg_name` in `sys.argv[1:]` as boolean or `default` value."""
-    value = _get_last_arg(arg_name)
+    value = _get_last_arg(arg_name, is_bool=True)
     if value in ['', '1', 'yes']:
         return True
     if value in ['0', 'no']:


### PR DESCRIPTION
Add flags for custom output control.

* `--bcce-color[=`_no_`]`           A boolean flag that enables or disables colored output. This is useful for environments where the color codes are not handled (e.g. VSCode output window).

* `--bcce-compiler[=`_compiler_`]`  Allows to override the detected compiler. This is helpful if the compiler found in the editor environment is different from the compiler that should be used for `compile_commands.json`.

* `--bcce-copt[=`_option_`]`        Enables passing additional `option`s to arg lists in  `compile_commands.json` (can be repeated).

Unlike in other PRs here all flags are prefixed with '--bcce-' (for Bazel-Compile-Command-Extractor) so they can easily be distinguished and filtered out.