### PR TITLE
Support ccache

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -760,6 +760,14 @@ def _all_platform_patch(compile_args: typing.List[str]):
             new_compile_args.append(arg)
     compile_args = new_compile_args
 
+    # replace ccache with the actual compiler
+    compiler_path = os.readlink(compile_args[0])
+    if compiler_path.endswith("ccache"):
+        compiler = os.path.basename(compile_args[0])
+        real_compiler_path = shutil.which(compiler)
+        if real_compiler_path:
+            compile_args[0] = real_compiler_path
+
     # Any other general fixes would go here...
 
     return compile_args

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -760,13 +760,17 @@ def _all_platform_patch(compile_args: typing.List[str]):
             new_compile_args.append(arg)
     compile_args = new_compile_args
 
-    # replace ccache with the actual compiler
-    compiler_path = os.readlink(compile_args[0])
-    if compiler_path.endswith("ccache"):
-        compiler = os.path.basename(compile_args[0])
-        real_compiler_path = shutil.which(compiler)
-        if real_compiler_path:
-            compile_args[0] = real_compiler_path
+    # Discover compilers that are actually symlinks to ccache--and replace them with the underlying compiler
+    try:
+        compiler_path = os.readlink(compile_args[0])
+    except OSError:
+        pass
+    else:
+        if compiler_path.endswith("ccache"):
+            compiler = os.path.basename(compile_args[0])
+            real_compiler_path = shutil.which(compiler)
+            if real_compiler_path:
+                compile_args[0] = real_compiler_path
 
     # Any other general fixes would go here...
 

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -761,12 +761,9 @@ def _all_platform_patch(compile_args: typing.List[str]):
     compile_args = new_compile_args
 
     # Discover compilers that are actually symlinks to ccache--and replace them with the underlying compiler
-    try:
+    if os.path.islink(compile_args[0]):
         compiler_path = os.readlink(compile_args[0])
-    except OSError:
-        pass
-    else:
-        if compiler_path.endswith("ccache"):
+        if os.path.basename(compiler_path) == "ccache":
             compiler = os.path.basename(compile_args[0])
             real_compiler_path = shutil.which(compiler)
             if real_compiler_path:


### PR DESCRIPTION
My project uses ccache not installed at the standard location and this leads to weird behaviors including generating all .o files in the workspace directory and clangd not able to find the correct gcc include paths.
The patch detects ccache usage and replace it with the actual compiler path.