### PR TITLE
Fix: exception when external link exists under windows and runfiles enabled

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -1281,7 +1281,7 @@ def _ensure_external_workspaces_link_exists():
         # Normalize the path for matching
         # First, workaround a gross case where Windows readlink returns extended path, starting with \\?\, causing the match to fail
         if is_windows:
-            current_dest = current_dest.removeprefix('\\\\?\\')
+            current_dest = str(current_dest).removeprefix('\\\\?\\')
         current_dest = pathlib.Path(current_dest)
 
         if dest != current_dest:

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -1281,8 +1281,7 @@ def _ensure_external_workspaces_link_exists():
         # Normalize the path for matching
         # First, workaround a gross case where Windows readlink returns extended path, starting with \\?\, causing the match to fail
         if is_windows:
-            current_dest = str(current_dest).removeprefix('\\\\?\\')
-        current_dest = pathlib.Path(current_dest)
+            current_dest = pathlib.Path(str(current_dest).removeprefix('\\\\?\\'))
 
         if dest != current_dest:
             log_warning(">>> //external links to the wrong place. Automatically deleting and relinking...")


### PR DESCRIPTION
I have observed an exception when using compile commands under windows with runfiles enabled.
The error is, that a windows path object has no method removeprefix.

Steps to reproduce:
- Enable Windows Developer mode and runfiles

# Options in .bazelrc
build --enable_runfiles
startup --windows_enable_symlinks
