### PR TITLE
Fix: Use os.readlink instead of Path.readlink before Python 3.9.

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -1305,7 +1305,7 @@ def _ensure_external_workspaces_link_exists():
         # This seemed to be the cleanest way to detect both.
         # Note that os.path.islink doesn't detect junctions.
         try:
-            current_dest = source.readlink()  # MIN_PY=3.9 source.readlink()
+            current_dest = os.readlink(source) # MIN_PY=3.9 source.readlink()
         except OSError:
             log_error(f">>> //external already exists, but it isn't a {'junction' if is_windows else 'symlink'}. //external is reserved by Bazel and needed for this tool. Please rename or delete your existing //external and rerun. More details in the README if you want them.") # Don't auto delete in case the user has something important there.
             sys.exit(1)

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -1305,7 +1305,7 @@ def _ensure_external_workspaces_link_exists():
         # This seemed to be the cleanest way to detect both.
         # Note that os.path.islink doesn't detect junctions.
         try:
-            current_dest = os.readlink(source) # MIN_PY=3.9 source.readlink()
+            current_dest = pathlib.Path(os.readlink(source)) # MIN_PY=3.9 source.readlink()
         except OSError:
             log_error(f">>> //external already exists, but it isn't a {'junction' if is_windows else 'symlink'}. //external is reserved by Bazel and needed for this tool. Please rename or delete your existing //external and rerun. More details in the README if you want them.") # Don't auto delete in case the user has something important there.
             sys.exit(1)


### PR DESCRIPTION
`Path.readlink` is not available before Python 3.9, which is causing the tool to complain in a project I'm working on. This code was implemented as `os.readlink()` before rules_python was introduced (per https://github.com/hedronvision/bazel-compile-commands-extractor/commit/0e5b1aa26d87a431d2a52676d0b9ce469448ee54), but didn't seem to be reverted when rules_python was reverted.

Verified locally that this fixes the issue for me.