### PR TITLE
Remove compile_commands.json before writing it

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -1414,6 +1414,11 @@ def main():
     There should be actionable warnings, above, that led to this.""")
         sys.exit(1)
 
+    try:
+        os.remove('compile_commands.json')
+    except FileNotFoundError:
+        pass
+
     # Chain output into compile_commands.json
     with open('compile_commands.json', 'w') as output_file:
         json.dump(


### PR DESCRIPTION
This fix existing as a symlink to a cmake directory seems like a pretty common use case, and the error when it fails to write is pretty inscrutable.

Fixes https://github.com/hedronvision/bazel-compile-commands-extractor/issues/105