### PR TITLE
Fallback to identifying source file by arguments.

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -617,6 +617,10 @@ def _get_files(compile_action):
 
     # First, we do the obvious thing: Filter args to those that look like source files.
     source_file_candidates = [arg for arg in compile_action.arguments if not arg.startswith('-') and arg.endswith(_get_files.source_extensions)]
+    if not source_file_candidates and len(compile_action.arguments) > 1:
+        for pos in range(len(compile_action.arguments) - 1):
+            if compile_action.arguments[pos] == '-c':
+                source_file_candidates = [compile_action.arguments[pos + 1]]
     assert source_file_candidates, f"No source files found in compile args: {compile_action.arguments}.\nPlease file an issue with this information!"
     source_file = source_file_candidates[0]
 


### PR DESCRIPTION
If source file cannot de identified from file extensions, then look for `-c <arg>`.