### PR TITLE
add output_dir feature

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -1415,7 +1415,7 @@ def main():
         sys.exit(1)
 
     # Chain output into compile_commands.json
-    with open('compile_commands.json', 'w') as output_file:
+    with open(os.path.join({output_dir}, 'compile_commands.json'), 'w') as output_file:
         json.dump(
             compile_command_entries,
             output_file,


### PR DESCRIPTION
This pull request is about to provide a support of writing out compile_commands.json relatively to workspace root to provide each project means of customizing their .clangd.

By default compile-commands-extractor's refresh_compile_command produces its output into bazel-workspace root. But our monorepository is single-rooted workspace and has many subprojects as children folders. Multiple projects are maintained by one team of developers, but a single project may have its own clangd configuration.

I didn't find any customization attribute of bazel target so created this PR. If there exist any please let me know. TY

@cpsauer it would be great if you find some time to review PR :)

Closes #217 