### PR TITLE
lower drive letter on win32

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -1155,7 +1155,7 @@ def _convert_compile_commands(aquery_output):
             dir = os.path.join(str(drive).lower(), path)
 
         return dir
-    
+
     dir = lower_drive_if_win32(os.environ["BUILD_WORKSPACE_DIRECTORY"])
 
     # Yield as compile_commands.json entries


### PR DESCRIPTION
I want to create compile_commands.json with 'directory' with lowered (explicitly specified) drive letter. 
This pullrequest is a workaround for a known clangd issue: https://github.com/clangd/clangd/issues/108

Clangd engine doesn't differ 'Windows paths' if they are provided by case-insensitive manner:
The two are treated if they are different:
- "C:/path/to/file"
- "c:/path/to/file"

Thus the engine response contains duplicate paths. They differ only by drive letter case. So VSCode API doesn't accept such reponses - e.g. it rejects to apply changes on 'applyEdits' (f2 key for refactoring).