### PR TITLE
[bugfix] AttributeError in refresh.template.py

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -501,7 +501,7 @@ def _file_is_in_main_workspace_and_not_external(file_str: str):
         workspace_absolute = pathlib.PurePath(os.environ["BUILD_WORKSPACE_DIRECTORY"])
         if not _is_relative_to(file_path, workspace_absolute):
             return False
-        file_path = _is_relative_to(file_path, workspace_absolute)
+        file_path = file_path.relative_to(workspace_absolute)
     # You can now assume that the path is relative to the workspace.
     # [Already assuming that relative paths are relative to the main workspace.]
 


### PR DESCRIPTION
AttributeError: 'bool' object has no attribute 'relative_to'

- Bug introduced during the reversion of changes (https://github.com/hedronvision/bazel-compile-commands-extractor/commit/0b821b7e4286aec887757461366f6eaaa0972cb9#diff-a1d7061df7c566a1f7656624ec608ad53dd3aff7a7789b9b6e4866a3b1616042R502).
- Reverted to the previous implementation to fix the issue.