### PR TITLE
Use ProcessPoolExecutor instead of ThreadPoolExecutor.

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -1142,8 +1142,8 @@ def _convert_compile_commands(aquery_output):
 
     # Process each action from Bazelisms -> file paths and their clang commands
     # Threads instead of processes because most of the execution time is farmed out to subprocesses. No need to sidestep the GIL. Might change after https://github.com/clangd/clangd/issues/123 resolved
-    with concurrent.futures.ThreadPoolExecutor(
-        max_workers=min(32, (os.cpu_count() or 1) + 4) # Backport. Default in MIN_PY=3.8. See "using very large resources implicitly on many-core machines" in https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
+    with concurrent.futures.ProcessPoolExecutor(
+        max_workers=os.cpu_count() # Default before Python 3.13, after which it is os.process_cpu_count().
     ) as threadpool:
         outputs = threadpool.map(_get_cpp_command_for_files, aquery_output.actions)
 


### PR DESCRIPTION
With the ThreadPoolExecutor, it was observed that the compile commands extractor was effectively running single threaded for substantial periods of time, most likely due to the GIL. CPU utilization was only about one core. Using a ProcessPoolExecutor to work around the GIL seems to provide a substantial performance benefit - it was about 6x faster in a test run.