### PR TITLE
add extension .h .hpp

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -691,8 +691,8 @@ def _get_files(compile_action):
 _get_files.has_logged_missing_file_error = False
 # Setup extensions and flags for the whole C-language family.
 # Clang has a list: https://github.com/llvm/llvm-project/blob/b9f3b7f89a4cb4cf541b7116d9389c73690f78fa/clang/lib/Driver/Types.cpp#L293
-_get_files.c_source_extensions = ('.c', '.i')
-_get_files.cpp_source_extensions = ('.cc', '.cpp', '.cxx', '.c++', '.C', '.CC', '.cp', '.CPP', '.C++', '.CXX', '.ii')
+_get_files.c_source_extensions = ('.c', '.i', '.h')
+_get_files.cpp_source_extensions = ('.cc', '.cpp', '.cxx', '.c++', '.C', '.CC', '.cp', '.CPP', '.C++', '.CXX', '.ii', '.hpp')
 _get_files.objc_source_extensions = ('.m',)
 _get_files.objcpp_source_extensions = ('.mm', '.M')
 _get_files.cuda_source_extensions = ('.cu', '.cui')


### PR DESCRIPTION
very nice work!
some target may build .h as the source file, like 'external/com_google_absl/absl/status/status.h' below:
```plain/text
bazel run :refresh_compile_commands
WARNING: Build options --features and --host_features have changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
INFO: Analyzed target //:refresh_compile_commands (1 packages loaded, 2925 targets configured).
INFO: Found 1 target...
Target //:refresh_compile_commands up-to-date:
  bazel-bin/refresh_compile_commands
  bazel-bin/refresh_compile_commands.check_python_version.py
  bazel-bin/refresh_compile_commands.py
INFO: Elapsed time: 0.569s, Critical Path: 0.02s
INFO: 2 processes: 2 internal.
INFO: Build completed successfully, 2 total actions
INFO: Running command line: bazel-bin/refresh_compile_commands
>>> Analyzing commands used in //mediapipe/tasks/c/vision/face_landmarker:libface_landmarker.dylib
WARNING: Build options --features and --host_features have changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_visla/1fadbad87b708b3a494498438939db80/execroot/mediapipe/bazel-out/darwin_arm64-fastbuild/bin/refresh_compile_commands.runfiles/mediapipe/refresh_compile_commands.check_python_version.py", line 15, in <module>
    refresh_compile_commands.main()
  File "/private/var/tmp/_bazel_visla/1fadbad87b708b3a494498438939db80/execroot/mediapipe/bazel-out/darwin_arm64-fastbuild/bin/refresh_compile_commands.py", line 1417, in main
    compile_command_entries.extend(_get_commands(target, flags))
  File "/private/var/tmp/_bazel_visla/1fadbad87b708b3a494498438939db80/execroot/mediapipe/bazel-out/darwin_arm64-fastbuild/bin/refresh_compile_commands.py", line 1279, in _get_commands
    yield from _convert_compile_commands(parsed_aquery_output)
  File "/private/var/tmp/_bazel_visla/1fadbad87b708b3a494498438939db80/execroot/mediapipe/bazel-out/darwin_arm64-fastbuild/bin/refresh_compile_commands.py", line 1159, in _convert_compile_commands
    for source_files, header_files, compile_command_args in outputs:
  File "/private/var/tmp/_bazel_visla/1fadbad87b708b3a494498438939db80/external/python_aarch64-apple-darwin/lib/python3.10/concurrent/futures/_base.py", line 621, in result_iterator
    yield _result_or_cancel(fs.pop())
  File "/private/var/tmp/_bazel_visla/1fadbad87b708b3a494498438939db80/external/python_aarch64-apple-darwin/lib/python3.10/concurrent/futures/_base.py", line 319, in _result_or_cancel
    return fut.result(timeout)
  File "/private/var/tmp/_bazel_visla/1fadbad87b708b3a494498438939db80/external/python_aarch64-apple-darwin/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/private/var/tmp/_bazel_visla/1fadbad87b708b3a494498438939db80/external/python_aarch64-apple-darwin/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/private/var/tmp/_bazel_visla/1fadbad87b708b3a494498438939db80/external/python_aarch64-apple-darwin/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/private/var/tmp/_bazel_visla/1fadbad87b708b3a494498438939db80/execroot/mediapipe/bazel-out/darwin_arm64-fastbuild/bin/refresh_compile_commands.py", line 1123, in _get_cpp_command_for_files
    source_files, header_files = _get_files(compile_action)
  File "/private/var/tmp/_bazel_visla/1fadbad87b708b3a494498438939db80/execroot/mediapipe/bazel-out/darwin_arm64-fastbuild/bin/refresh_compile_commands.py", line 621, in _get_files
    assert source_file_candidates, f"No source files found in compile args: {compile_action.arguments}.\nPlease file an issue with this information!"
AssertionError: No source files found in compile args: ['clang', '-xc++-header', '-fsyntax-only', '-D_FORTIFY_SOURCE=1', '-fstack-protector', '-fcolor-diagnostics', '-Wall', '-Wthread-safety', '-Wself-assign', '-fno-omit-frame-pointer', '-O0', '-DDEBUG', '-iquote', 'external/com_google_absl', '-iquote', 'bazel-out/darwin_arm64-fastbuild/bin/external/com_google_absl', '-MD', '-MF', 'bazel-out/darwin_arm64-fastbuild/bin/external/com_google_absl/absl/status/_objs/status/status.h.d', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk', '-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks', '-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks', '-no-canonical-prefixes', '-pthread', '-w', '-std=c++17', '-Wall', '-Wextra', '-Wcast-qual', '-Wconversion', '-Wfloat-overflow-conversion', '-Wfloat-zero-conversion', '-Wfor-loop-analysis', '-Wformat-security', '-Wgnu-redeclared-enum', '-Winfinite-recursion', '-Winvalid-constexpr', '-Wliteral-conversion', '-Wmissing-declarations', '-Woverlength-strings', '-Wpointer-arith', '-Wself-assign', '-Wshadow-all', '-Wshorten-64-to-32', '-Wsign-conversion', '-Wstring-conversion', '-Wtautological-overlap-compare', '-Wtautological-unsigned-zero-compare', '-Wundef', '-Wuninitialized', '-Wunreachable-code', '-Wunused-comparison', '-Wunused-local-typedefs', '-Wunused-result', '-Wvla', '-Wwrite-strings', '-Wno-float-conversion', '-Wno-implicit-float-conversion', '-Wno-implicit-int-float-conversion', '-Wno-unknown-warning-option', '-DNOMINMAX', '-std=c++17', '-no-canonical-prefixes', '-Wno-builtin-macro-redefined', '-D__DATE__="redacted"', '-D__TIMESTAMP__="redacted"', '-D__TIME__="redacted"', '-target', 'arm64-apple-macosx15.5', '-c', 'external/com_google_absl/absl/status/status.h', '-o', 'bazel-out/darwin_arm64-fastbuild/bin/external/com_google_absl/absl/status/_objs/status/status.h.processed'].
Please file an issue with this information!
```