### PR TITLE
Support --symlink-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,23 @@ Adding `exclude_external_sources = True` and `exclude_headers = "external"` can 
 
 For now, we'd suggest continuing on to set up `clangd` (below). Thereafter, if you your project proves to be large enough that it stretches the capacity of `clangd` and/or this tool to index quickly, take a look at the docs at the top of [`refresh_compile_commands.bzl`](./refresh_compile_commands.bzl) for instructions on how to tune those flags and others.
 
+### ⚠️ EXPERIMENTAL FEATURE: --symlink-prefix support
+
+Bazel allows use of the --symlink-prefix argument, commonly in `.bazelrc`, ie `build --symlink_prefix=build/bazel-`. Using this can help keep your workspace tidy by changing the names of the generated symlinks or even putting them in a subdirectory. Experimental support for this feature can be used by adding `experimental_symlink_prefix = <your_prefix>` to your rule. Make sure the prefix you add here matches what you use with bazel commands/.bazelrc! For example:
+
+```Starlark
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+    experimental_symlink_prefix = "build/bazel-",
+)
+```
+
+This will tell the tool to expect symlinks with the prefix `build/bazel-` instead of `bazel-`. It will also place the `external` directory symlink in the subdirectory associated with the prefix (if any), ie `build/` to keep things tidy and the subdirectory matching bazel's build workspace.
+
+**IMPORTANT ADDITIONAL REQUIREMENT:**
+
+If you use a symlink prefix with a subdirectory, the `external` folder will no longer be in the project root. Bazel will no longer ignore it by default, and will try to look for targets inside it too, which will cause many commands to fail. To avoid this, you'll need to add a `.bazelignore` file to the root of your project, and add `build` or `build/external` to it.
+
 ## Editor Setup — for autocomplete based on `compile_commands.json`
 
 


### PR DESCRIPTION
Adjusting the symlink prefix is useful both for organisation (putting in a subdirectory) as well as performance in some IDEs. This is an experimental feature that uses a thorough regex search and replace on each compiler parameter to update paths matching the symlink prefix.

This applies to the commands before they go through the compiler stages, hence everything else in the script including caching etc works seamlessly. There are minor changes to the automated symlink creation and detection function.

Regex Assumptions:
1) `bazel-out` and `external` are the only simlinks used in compile_commands.json
2) These paths only appear at the begining of a string (ie `"bazel-out/..` `"-Ibazel-out/...` etc) or after an argument's = in a string (ie `-frandom-seed=bazel-out/...`)
3) In the case of a direct prefix to the path (ie `-I`), it will always begin with at least one - or / (MSVC) and be followed by only alphanumeric characters, `-` and `_` up until the `bazel-out/` or `external/` section
4) Optionally, an = will be matched before the path

Full Regex for testing: [^(?P<content>(?:[-/][a-zA-Z0-9\-_]+)?=?)(?P<prefix>bazel-out|external)/](https://regex101.com/r/sOGoV3/2) 

Known considerations:
Doesn't attempt to deal with flags which contain multiple comma deliniated values after =, ie `"--extract-api-ignores=foo,external/bar,baz"`
In order to deal with flags like this, we'd need to be able to tell whether the comma is part of the path or separating paths. So far I haven't come across any flags like this, and presumably they'd be split up into multiple flags by default unless it was a user custom added one. Cross that bridge when we get to it.

TODO:
Windows should work but needs testing