### PR TITLE
fix: skip .S compiles for msvc/windows

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -587,6 +587,9 @@ def _get_headers(compile_action, source_path: str):
 
     if compile_action.arguments[0].endswith('cl.exe'): # cl.exe and also clang-cl.exe
         headers, should_cache = _get_headers_msvc(compile_action, source_path)
+    elif compile_action.arguments[0].endswith('ml.exe') or compile_action.arguments[0].endswith('ml64.exe'): # skip when compiling .S MASM files on Windows
+        headers = set()
+        should_cache = False
     else:
         headers, should_cache = _get_headers_gcc(compile_action, source_path, compile_action.actionKey)
 


### PR DESCRIPTION
I was getting this error while compiling libraries that use `.S` as input files which run through msvc masm compiler. Just adding the skip works for me.

```
AssertionError: Something went wrong in makefile parsing to get headers. The target should be an object file. Output:
MASM : warning A4018:invalid command-line option : /bigobj
MASM : warning A4018:invalid command-line option : /Zm500
MASM : warning A4018:invalid command-line option : /Z500
MASM : warning A4018:invalid command-line option : /Z00
MASM : warning A4018:invalid command-line option : /Z0
MASM : warning A4018:invalid command-line option : /EHsc
MASM : warning A4018:invalid command-line option : /wd4351
MASM : warning A4018:invalid command-line option : /wd4291
MASM : warning A4018:invalid command-line option : /wd4250
MASM : warning A4018:invalid command-line option : /wd4996
MASM : warning A4018:invalid command-line option : /showIncludes
 Assembling: bazel-out/x64_windows-fastbuild/bin/external/boost.context+/src/asm/jump_x86_64_ms_pe_masm.S
bazel-out/x64_windows-fastbuild/bin/external/boost.context+/src/asm/jump_x86_64_ms_pe_masm.S(1) : fatal error A1000:cannot open file : bazel-out/x64_windows-fastbuild/bin/external/boost.context+/_objs/boost.context/jump_x86_64_ms_pe_masm.obj   
```