### PR TITLE
Fix no value environment variables in refresh.template.py

### DIFF
--- a/refresh.template.py
+++ b/refresh.template.py
@@ -1109,7 +1109,7 @@ def _get_cpp_command_for_files(compile_action):
             compile_action[pair.key] = pair.value
         else:
             compile_action[pair.key] = ""
-    
+
     if 'PATH' not in compile_action.environmentVariables: # Bazel only adds if --incompatible_strict_action_env is passed--and otherwise inherits.
         compile_action.environmentVariables['PATH'] = os.environ['PATH']
 

--- a/refresh.template.py
+++ b/refresh.template.py
@@ -1103,7 +1103,13 @@ def _get_cpp_command_for_files(compile_action):
     Undo Bazel-isms and figures out which files clangd should apply the command to.
     """
     # Condense aquery's environment variables into a dictionary, the format you might expect.
-    compile_action.environmentVariables = {pair.key: pair.value for pair in getattr(compile_action, 'environmentVariables', [])}
+    compile_action.environmentVariables = {}
+    for pair in getattr(compile_action, 'environmentVariables', []):
+        if hasattr(pair, 'value'):
+            compile_action[pair.key] = pair.value
+        else:
+            compile_action[pair.key] = ""
+    
     if 'PATH' not in compile_action.environmentVariables: # Bazel only adds if --incompatible_strict_action_env is passed--and otherwise inherits.
         compile_action.environmentVariables['PATH'] = os.environ['PATH']
 


### PR DESCRIPTION
Fix issue where environment variable has no value reported in bazel query.