### PR TITLE
Fix Bazel 9 rule loading; document WORKSPACE deps

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load(":refresh_compile_commands.bzl", "refresh_compile_commands")
 
 # See README.md for interface.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,9 @@
 module(name = "hedron_compile_commands")
 
+bazel_dep(name = "rules_python", version = "1.8.0")
+
+bazel_dep(name = "rules_cc", version = "0.2.16")
+
 p = use_extension("//:workspace_setup.bzl", "hedron_compile_commands_extension")
 pt = use_extension("//:workspace_setup_transitive.bzl", "hedron_compile_commands_extension")
 ptt = use_extension("//:workspace_setup_transitive_transitive.bzl", "hedron_compile_commands_extension")

--- a/README.md
+++ b/README.md
@@ -68,6 +68,22 @@ Copy this into the top of your Bazel `WORKSPACE` file, making sure to update to 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 
+# Bazel 9+: py_binary/cc_binary are no longer native, so make sure rules_python and rules_cc are present.
+# If you already use these, you can omit this block.
+http_archive(
+    name = "rules_python",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/1.8.0/rules_python-1.8.0.tar.gz",
+    # Replace the version above with the latest release from https://github.com/bazelbuild/rules_python/releases.
+    # sha256 = "...",
+)
+http_archive(
+    name = "rules_cc",
+    url = "https://github.com/bazelbuild/rules_cc/releases/download/0.2.16/rules_cc-0.2.16.tar.gz",
+    # Replace the version above with the latest release from https://github.com/bazelbuild/rules_cc/releases.
+    # sha256 = "...",
+)
+
+
 # Hedron's Compile Commands Extractor for Bazel
 # https://github.com/hedronvision/bazel-compile-commands-extractor
 http_archive(

--- a/refresh_compile_commands.bzl
+++ b/refresh_compile_commands.bzl
@@ -57,6 +57,7 @@ refresh_compile_commands(
 # Implementation
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 
 def refresh_compile_commands(
@@ -92,7 +93,7 @@ def refresh_compile_commands(
     _expand_template(name = script_name, labels_to_flags = targets, exclude_headers = exclude_headers, exclude_external_sources = exclude_external_sources, **kwargs)
 
     # Combine them so the wrapper calls the main script
-    native.py_binary(
+    py_binary(
         name = name,
         main = version_checker_script_name,
         srcs = [version_checker_script_name, script_name],


### PR DESCRIPTION
## Problem
Bazel 9 removed native `py_binary` and `cc_binary`, so loading this repo fails on Bazel 9.

## Changes
  - Load `py_binary` from `@rules_python` in `refresh_compile_commands.bzl`
  - Load `cc_binary` from `@rules_cc` in `BUILD`
  - Add `rules_python` and `rules_cc` to `MODULE.bazel` for bzlmod users
  - Document WORKSPACE setup for Bazel 9 in README

## Testing
  - `bazel run @hedron_compile_commands//:refresh_all` in a Bazel 9 workspace

## Compatibility
  - Works for Bazel versions that support `rules_python`/`rules_cc` (Bazel 6+).
  - WORKSPACE users need the extra `http_archive` entries for Bazel 9.