### PR TITLE
Support bazel 9

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -8,24 +8,25 @@ refresh_compile_commands(
     name = "refresh_all",
 )
 
-
 # Stardoc users only: Depend on "@hedron_compile_commands//:bzl_srcs_for_stardoc" as needed.
 # Why? Stardoc requires all loaded files to be listed as deps; without this we'd prevent users from running Stardoc on their code when they load from this tool in, e.g., their own workspace.bzl or wrapping macros.
 filegroup(
     name = "bzl_srcs_for_stardoc",
-    visibility = ["//visibility:public"],
     srcs = glob(["**/*.bzl"]) + [
         "@bazel_tools//tools:bzl_srcs",
     ],
+    visibility = ["//visibility:public"],
 )
-
-
 
 ########################################
 # Implementation:
 # If you are looking into the implementation, start with the overview in ImplementationReadme.md.
 
-exports_files(["refresh.template.py", "check_python_version.template.py"])  # For implicit use by the refresh_compile_commands macro, not direct use.
+# For implicit use by the refresh_compile_commands macro, not direct use.
+exports_files([
+    "refresh.template.py",
+    "check_python_version.template.py",
+])
 
 cc_binary(
     name = "print_args",

--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load(":refresh_compile_commands.bzl", "refresh_compile_commands")
 
 # See README.md for interface.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,8 @@
 module(name = "hedron_compile_commands")
 
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_python", version = "1.9.0")
+
 p = use_extension("//:workspace_setup.bzl", "hedron_compile_commands_extension")
 pt = use_extension("//:workspace_setup_transitive.bzl", "hedron_compile_commands_extension")
 ptt = use_extension("//:workspace_setup_transitive_transitive.bzl", "hedron_compile_commands_extension")

--- a/refresh_compile_commands.bzl
+++ b/refresh_compile_commands.bzl
@@ -52,12 +52,10 @@ refresh_compile_commands(
 ```
 """
 
-
 ########################################
 # Implementation
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-
 
 def refresh_compile_commands(
         name,
@@ -80,7 +78,8 @@ def refresh_compile_commands(
 
     # Make any package-relative labels absolute
     targets = {
-        target if target.startswith("/") or target.startswith("@") else "{}//{}:{}".format(native.repository_name(), native.package_name(), target.removeprefix(":")): flags for target, flags in targets.items()
+        target if target.startswith("/") or target.startswith("@") else "{}//{}:{}".format(native.repository_name(), native.package_name(), target.removeprefix(":")): flags
+        for target, flags in targets.items()
     }
 
     # Create a wrapper script that prints a helpful error message if the python version is too old, generated from check_python_version.template.py
@@ -97,7 +96,7 @@ def refresh_compile_commands(
         main = version_checker_script_name,
         srcs = [version_checker_script_name, script_name],
         data = ["@hedron_compile_commands//:print_args"],
-        imports = [''], # Allows binary to import templated script, even if this macro is being called inside a sub package. See https://github.com/hedronvision/bazel-compile-commands-extractor/issues/137
+        imports = [""],  # Allows binary to import templated script, even if this macro is being called inside a sub package. See https://github.com/hedronvision/bazel-compile-commands-extractor/issues/137
         **kwargs
     )
 
@@ -149,7 +148,7 @@ def _check_python_version_impl(ctx):
 
 _check_python_version = rule(
     attrs = {
-        "to_run": attr.string(mandatory = True), # Name of the python module (no .py) to import and call .main() on, should checks succeed.
+        "to_run": attr.string(mandatory = True),  # Name of the python module (no .py) to import and call .main() on, should checks succeed.
         "_template": attr.label(allow_single_file = True, default = "check_python_version.template.py"),
     },
     implementation = _check_python_version_impl,

--- a/refresh_compile_commands.bzl
+++ b/refresh_compile_commands.bzl
@@ -56,6 +56,7 @@ refresh_compile_commands(
 # Implementation
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_python//python:py_binary.bzl", "py_binary")
 
 def refresh_compile_commands(
         name,
@@ -91,7 +92,7 @@ def refresh_compile_commands(
     _expand_template(name = script_name, labels_to_flags = targets, exclude_headers = exclude_headers, exclude_external_sources = exclude_external_sources, **kwargs)
 
     # Combine them so the wrapper calls the main script
-    native.py_binary(
+    py_binary(
         name = name,
         main = version_checker_script_name,
         srcs = [version_checker_script_name, script_name],


### PR DESCRIPTION
# Changes
- Bazel 9 does not have native rules
- Need to explicitly bring in `rules_cc` and `rules_python`
- Fixes #279